### PR TITLE
🔀 :: 회원가입 스크린 상태관리 #104 

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,7 +5,9 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:intl/intl.dart';
+import 'package:mukgen_flutter_v1/observe.dart';
 import 'package:mukgen_flutter_v1/screen/sign_in/bloc/sign_in_bloc.dart';
+import 'package:mukgen_flutter_v1/screen/sign_up/bloc/sign_up_bloc.dart';
 import 'package:mukgen_flutter_v1/screen/starting_page.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:mukgen_flutter_v1/secret.dart';
@@ -15,6 +17,7 @@ void main() {
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
   String flareLaneKey = getFlareLaneKey(); // 별도의 함수를 사용해 키를 가져옴
   FlareLane.shared.initialize(flareLaneKey);
+  Bloc.observer = Observer();
   initializeDateFormatting().then((_) {
     Intl.defaultLocale = 'ko_KR';
     SystemChrome.setPreferredOrientations([
@@ -51,6 +54,7 @@ class _MyAppState extends State<MyApp> {
     return MultiBlocProvider(
       providers: [
         BlocProvider(create: (context) => SignInBloc()),
+        BlocProvider(create: (context) => SignUpBloc()),
       ],
       child: ScreenUtilInit(
         designSize: const Size(393, 852),

--- a/lib/observe.dart
+++ b/lib/observe.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class Observer extends BlocObserver {
+  @override
+  void onCreate(BlocBase bloc) {
+    print("Create :: $bloc");
+    super.onCreate(bloc);
+  }
+
+  @override
+  void onClose(BlocBase bloc) {
+    print("Close :: $bloc");
+    super.onClose(bloc);
+  }
+
+  @override
+  void onChange(BlocBase bloc, Change change) {
+    print(change);
+    super.onChange(bloc, change);
+  }
+}

--- a/lib/screen/sign_in/bloc/sign_in_bloc.dart
+++ b/lib/screen/sign_in/bloc/sign_in_bloc.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mukgen_flutter_v1/screen/sign_in/bloc/sign_in_event.dart';
 import 'package:mukgen_flutter_v1/screen/sign_in/bloc/sign_in_state.dart';

--- a/lib/screen/sign_in/bloc/sign_in_event.dart
+++ b/lib/screen/sign_in/bloc/sign_in_event.dart
@@ -11,3 +11,9 @@ class LoadSignIn extends SignInEvent {
   @override
   List<Object?> get props => [accountId, password];
 }
+
+class ResetEvent extends SignInEvent {
+
+  @override
+  List<Object?> get props => [];
+}

--- a/lib/screen/sign_in/view/login_page.dart
+++ b/lib/screen/sign_in/view/login_page.dart
@@ -29,8 +29,6 @@ class _LoginPageState extends State<LoginPage> {
   final storage = const FlutterSecureStorage();
   dynamic userInfo = '';
 
-  final signInBloc = SignInBloc();
-
   @override
   void initState() {
     super.initState();
@@ -42,7 +40,6 @@ class _LoginPageState extends State<LoginPage> {
 
   @override
   void dispose() {
-    signInBloc.close();
     idController.dispose();
     pwdController.dispose();
     super.dispose();
@@ -51,7 +48,8 @@ class _LoginPageState extends State<LoginPage> {
   void _updateButtonState() {
     setState(() {
       ValidateLogin.loginValue = '';
-      _isButtonEnabled = idController.text.isNotEmpty && pwdController.text.isNotEmpty;
+      _isButtonEnabled =
+          idController.text.isNotEmpty && pwdController.text.isNotEmpty;
     });
   }
 
@@ -76,26 +74,25 @@ class _LoginPageState extends State<LoginPage> {
           ),
         ),
       ),
-      body: SizedBox(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.start,
-          children: [
-            SizedBox(height: 40.0.h),
-            Container(
-              alignment: Alignment.topLeft,
-              margin: EdgeInsets.only(left: 20.0.w),
-              child: Text(
-                '로그인을 위한\n정보를 입력해주세요.',
-                style: TextStyle(
-                  fontSize: 24.0.sp,
-                  fontWeight: FontWeight.w600,
-                  fontFamily: 'MukgenSemiBold',
-                ),
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: [
+          SizedBox(height: 40.0.h),
+          Container(
+            alignment: Alignment.topLeft,
+            margin: EdgeInsets.only(left: 20.0.w),
+            child: Text(
+              '로그인을 위한\n정보를 입력해주세요.',
+              style: TextStyle(
+                fontSize: 24.0.sp,
+                fontWeight: FontWeight.w600,
+                fontFamily: 'MukgenSemiBold',
               ),
             ),
-            BlocBuilder<SignInBloc, SignInState>(
-              bloc: signInBloc,
-              builder: (context, state) {
+          ),
+          Expanded(
+            child: BlocConsumer<SignInBloc, SignInState>(
+              listener: (context, state) {
                 if (state is Error) {
                   ValidateLogin.loginValue = '아이디나 비밀번호가 맞지 않습니다.';
                 }
@@ -142,7 +139,7 @@ class _LoginPageState extends State<LoginPage> {
                           actions: <Widget>[
                             Padding(
                               padding:
-                                  EdgeInsets.only(bottom: 10.0.h, left: 4.0.w),
+                              EdgeInsets.only(bottom: 10.0.h, left: 4.0.w),
                               child: MukGenButton(
                                 text: "확인",
                                 width: 285,
@@ -152,11 +149,11 @@ class _LoginPageState extends State<LoginPage> {
                                 textColor: MukGenColor.white,
                                 onPressed: () {
                                   if (_isButtonEnabled) {
-                                    Navigator.of(context).pushAndRemoveUntil(
-                                        MaterialPageRoute(
-                                            builder: (context) =>
-                                                const MainNavigator()),
-                                        (route) => false);
+                                    Future.microtask(
+                                          () => Navigator.of(context).push(MaterialPageRoute(
+                                        builder: (context) => const MainNavigator(),
+                                      )).then((_) => context.read<SignInBloc>().add(ResetEvent())), // 다른 화면으로 이동 -> 상태 초기화
+                                    );
                                   }
                                 },
                               ),
@@ -168,6 +165,8 @@ class _LoginPageState extends State<LoginPage> {
                     );
                   });
                 }
+              },
+              builder: (context, state) {
                 return Column(
                   children: [
                     SizedBox(height: 24.0.h),
@@ -192,6 +191,7 @@ class _LoginPageState extends State<LoginPage> {
                       helperText: ValidateLogin.loginValue,
                       color: MukGenColor.red,
                     ),
+                    const Spacer(),
                     MukGenButton(
                       text: "로그인",
                       width: 352,
@@ -203,21 +203,16 @@ class _LoginPageState extends State<LoginPage> {
                       textColor: MukGenColor.white,
                       onPressed: _isButtonEnabled
                           ? () {
-                              signInBloc.add(
-                                LoadSignIn(
-                                  accountId: idController.text,
-                                  password: pwdController.text,
-                                ),
-                              );
-                            }
+                        context.read<SignInBloc>().add(LoadSignIn(accountId: idController.text, password: pwdController.text));
+                      }
                           : null,
                     ),
                   ],
                 );
               },
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/screen/sign_up/bloc/sign_up_bloc.dart
+++ b/lib/screen/sign_up/bloc/sign_up_bloc.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mukgen_flutter_v1/model/auth/duplicate_response.dart';
+import 'package:mukgen_flutter_v1/screen/sign_up/bloc/sign_up_event.dart';
+import 'package:mukgen_flutter_v1/screen/sign_up/bloc/sign_up_state.dart';
+import 'package:mukgen_flutter_v1/service/auth_service.dart';
+import 'package:mukgen_flutter_v1/service/mail_service.dart';
+
+class SignUpBloc extends Bloc<SignUpEvent, SignUpState> {
+  SignUpBloc() : super(Empty()) {
+    on<LoadEmailInput>((event, emit) async {
+      try {
+        emit(Loaded(
+            response: MailService.postSendMailInfo(event.mail).toString()));
+      } catch (e) {
+        emit(Error(message: e.toString()));
+      }
+    });
+
+    on<LoadEmailConfirm>((event, emit) async {
+      try {
+        final confirm =
+            await MailService.postAuthenticateMailInfo(event.mail, event.code);
+        if (confirm == false) {
+          throw Exception();
+        } else {
+          emit(Loaded(response: confirm.toString()));
+        }
+      } catch (e) {
+        emit(Error(message: e.toString()));
+      }
+    });
+
+    on<ReloadEmailInput>((event, emit) async {
+      try {
+        emit(Reloaded(
+            response: MailService.postSendMailInfo(event.mail).toString()));
+      } catch (e) {
+        emit(Error(message: e.toString()));
+      }
+    });
+
+    on<LoadIdDuplicate>((event, emit) async {
+      try {
+        final DuplicateResponse response =
+            await AuthService.getDuplicateInfo(event.id);
+        if (response.duplicate == true) {
+          throw Exception();
+        } else {
+          emit(Loaded(response: response.toString()));
+        }
+      } catch (e) {
+        emit(Error(message: e.toString()));
+      }
+    });
+
+    on<LoadSignUp>((event, emit) async {
+      try {
+        emit(Loaded(
+            response: AuthService.postGeneralSignupInfo(
+          event.nickname,
+          event.accountId,
+          event.password,
+          event.passwordCheck,
+          event.phoneNumber,
+          event.mail,
+        ).toString()));
+      } catch (e) {
+        emit(Error(message: e.toString()));
+      }
+    });
+
+    on<ResetEvent>((event, emit) => emit(Empty()));
+  }
+}

--- a/lib/screen/sign_up/bloc/sign_up_event.dart
+++ b/lib/screen/sign_up/bloc/sign_up_event.dart
@@ -1,0 +1,61 @@
+import 'package:equatable/equatable.dart';
+
+abstract class SignUpEvent extends Equatable {}
+
+class LoadEmailInput extends SignUpEvent {
+  final String mail;
+
+  LoadEmailInput({required this.mail});
+
+  @override
+  List<Object?> get props => [mail];
+}
+
+class LoadEmailConfirm extends SignUpEvent {
+  final String mail;
+  final String code;
+
+  LoadEmailConfirm({required this.code, required this.mail});
+
+  @override
+  List<Object?> get props => [code, mail];
+}
+
+class ReloadEmailInput extends SignUpEvent {
+  final String mail;
+
+  ReloadEmailInput({required this.mail});
+
+  @override
+  List<Object?> get props => [mail];
+}
+
+class LoadIdDuplicate extends SignUpEvent {
+  final String id;
+
+
+  LoadIdDuplicate({required this.id});
+
+  @override
+  List<Object?> get props => [id];
+}
+
+class LoadSignUp extends SignUpEvent {
+  final String nickname;
+  final String accountId;
+  final String password;
+  final String passwordCheck;
+  final String phoneNumber;
+  final String mail;
+
+  LoadSignUp({required this.nickname, required this.accountId, required this.password, required this.passwordCheck, required this.phoneNumber, required this.mail});
+
+  @override
+  List<Object?> get props => [nickname, accountId, password, passwordCheck, phoneNumber, mail];
+}
+
+class ResetEvent extends SignUpEvent {
+
+  @override
+  List<Object?> get props => [];
+}

--- a/lib/screen/sign_up/bloc/sign_up_state.dart
+++ b/lib/screen/sign_up/bloc/sign_up_state.dart
@@ -1,0 +1,35 @@
+import 'package:equatable/equatable.dart';
+
+abstract class SignUpState extends Equatable {}
+
+class Empty extends SignUpState {
+  @override
+  List<Object> get props => [];
+}
+
+class Error extends SignUpState {
+  final String message;
+
+  Error({required this.message});
+
+  @override
+  List<Object> get props => [message];
+}
+
+class Loaded extends SignUpState {
+  final String response;
+
+  Loaded({required this.response});
+
+  @override
+  List<Object> get props => [response];
+}
+
+class Reloaded extends SignUpState { // API를 다시 전송 했을 때 Loaded로 상태가 변경되어 화면이 넘어가는 것을 방지
+  final String response;
+
+  Reloaded({required this.response});
+
+  @override
+  List<Object> get props => [response];
+}

--- a/lib/screen/sign_up/view/sign_up_email_input_page.dart
+++ b/lib/screen/sign_up/view/sign_up_email_input_page.dart
@@ -39,7 +39,6 @@ class _SignupEmailInputPageState extends State<SignupEmailInputPage> {
 
   @override
   Widget build(BuildContext context) {
-    String mail = "${emailController.text}@dsm.hs.kr";
     return Scaffold(
       backgroundColor: MukGenColor.white,
       appBar: AppBar(
@@ -137,7 +136,7 @@ class _SignupEmailInputPageState extends State<SignupEmailInputPage> {
               if (state is Loaded) {
                 Future.microtask(
                   () => Navigator.of(context).push(MaterialPageRoute(
-                    builder: (context) => SignupEmailConfirmPage(email: mail),
+                    builder: (context) => SignupEmailConfirmPage(email: "${emailController.text}@dsm.hs.kr"),
                   )).then((_) => context.read<SignUpBloc>().add(ResetEvent())), // 다른 화면으로 이동 -> 상태 초기화
                 );
               }
@@ -154,7 +153,7 @@ class _SignupEmailInputPageState extends State<SignupEmailInputPage> {
                 textColor: MukGenColor.white,
                 onPressed: () {
                   if (_isButtonEnabled) {
-                    context.read<SignUpBloc>().add(LoadEmailInput(mail: mail));
+                    context.read<SignUpBloc>().add(LoadEmailInput(mail: "${emailController.text}@dsm.hs.kr"));
                   }
                 },
               );

--- a/lib/screen/sign_up/view/sign_up_id_pw_page.dart
+++ b/lib/screen/sign_up/view/sign_up_id_pw_page.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mukgen_flutter_v1/common/common.dart';
+import 'package:mukgen_flutter_v1/screen/sign_up/bloc/sign_up_bloc.dart';
+import 'package:mukgen_flutter_v1/screen/sign_up/bloc/sign_up_event.dart';
+import 'package:mukgen_flutter_v1/screen/sign_up/bloc/sign_up_state.dart';
 import 'package:mukgen_flutter_v1/screen/sign_up/view/sign_up_number_page.dart';
 import 'package:mukgen_flutter_v1/service/auth_service.dart';
 import 'package:mukgen_flutter_v1/widget/mukgen_button.dart';
@@ -51,6 +55,7 @@ class _SignupIdPwPageState extends State<SignupIdPwPage> {
         DuplicateResult.isDuplicate = false;
         idValid = Validation.getIdValidation(currentIdValue);
         idColor = Validation.getIdFieldColor(currentIdValue);
+        context.read<SignUpBloc>().add(ResetEvent());
       });
 
       _previousIdValue = currentIdValue;
@@ -60,7 +65,7 @@ class _SignupIdPwPageState extends State<SignupIdPwPage> {
           Validation.getPwdValidation(pwdController.text).contains("사용 가능한") &&
           Validation.getPwdValidation(pwdCheckController.text,
                   confirmPassword: pwdController.text)
-              .contains("일치");
+              .contains("일치합니다");
     });
   }
 
@@ -113,90 +118,94 @@ class _SignupIdPwPageState extends State<SignupIdPwPage> {
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Stack(
-                alignment: Alignment.topRight,
-                children: [
-                  SizedBox(
-                    width: 352.0.w,
-                    child: TextFormField(
-                      controller: idController,
-                      cursorColor: MukGenColor.black,
-                      style: TextStyle(
-                        color: MukGenColor.black,
-                        fontSize: 20.sp,
-                        fontWeight: FontWeight.w600,
-                        fontFamily: 'MukgenSemiBold',
-                      ),
-                      decoration: InputDecoration(
-                        helperText: idValid,
-                        helperStyle: TextStyle(
-                          color: idColor,
-                          fontSize: 16.sp,
-                          fontFamily: 'MukgenRegular',
-                          fontWeight: FontWeight.w400,
-                        ),
-                        hintText: "아이디",
-                        hintStyle: TextStyle(
-                          color: MukGenColor.primaryLight2,
-                          fontSize: 20.sp,
-                          fontWeight: FontWeight.w600,
-                          fontFamily: 'MukgenSemiBold',
-                        ),
-                        enabledBorder: idController.text.isEmpty
-                            ? UnderlineInputBorder(
-                                borderSide: BorderSide(
-                                  color: MukGenColor.primaryLight2,
-                                  width: 2,
-                                ),
-                              )
-                            : UnderlineInputBorder(
-                                borderSide: BorderSide(
-                                  color: MukGenColor.black,
-                                  width: 2,
-                                ),
-                              ),
-                        focusedBorder: UnderlineInputBorder(
-                          borderSide: BorderSide(
-                            color: MukGenColor.pointBase,
-                            width: 2,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-                  GestureDetector(
-                    onTap: () async {
-                      await AuthService.getDuplicateInfo(idController.text)
-                          .then((value) => DuplicateResult.duplicateState =
-                              value.duplicate!);
-                      DuplicateResult.isDuplicate = true;
-                      idValid = Validation.getIdValidation(idController.text);
-                      idColor = Validation.getIdFieldColor(idController.text);
-                      setState(() {});
-                    },
-                    child: Container(
-                      width: 84.0.w,
-                      height: 37.0.h,
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(6.r),
-                        border: Border.all(
-                          color: MukGenColor.primaryLight2,
-                        ),
-                      ),
-                      child: Center(
-                        child: Text(
-                          '중복 확인',
+              BlocConsumer<SignUpBloc, SignUpState>(
+                listener: (context, state) {
+                  if (state is Loaded) {
+                    idValid = '사용 가능한 아이디입니다.';
+                    idColor = MukGenColor.green;
+                  }
+                },
+                builder: (context, state) {
+                  return Stack(
+                    alignment: Alignment.topRight,
+                    children: [
+                      SizedBox(
+                        width: 352.0.w,
+                        child: TextFormField(
+                          controller: idController,
+                          cursorColor: MukGenColor.black,
                           style: TextStyle(
-                            color: MukGenColor.primaryDark2,
+                            color: MukGenColor.black,
+                            fontSize: 20.sp,
                             fontWeight: FontWeight.w600,
-                            fontSize: 14.sp,
                             fontFamily: 'MukgenSemiBold',
                           ),
+                          decoration: InputDecoration(
+                            helperText: idValid,
+                            helperStyle: TextStyle(
+                              color: idColor,
+                              fontSize: 16.sp,
+                              fontFamily: 'MukgenRegular',
+                              fontWeight: FontWeight.w400,
+                            ),
+                            hintText: "아이디",
+                            hintStyle: TextStyle(
+                              color: MukGenColor.primaryLight2,
+                              fontSize: 20.sp,
+                              fontWeight: FontWeight.w600,
+                              fontFamily: 'MukgenSemiBold',
+                            ),
+                            enabledBorder: idController.text.isEmpty
+                                ? UnderlineInputBorder(
+                                    borderSide: BorderSide(
+                                      color: MukGenColor.primaryLight2,
+                                      width: 2,
+                                    ),
+                                  )
+                                : UnderlineInputBorder(
+                                    borderSide: BorderSide(
+                                      color: MukGenColor.black,
+                                      width: 2,
+                                    ),
+                                  ),
+                            focusedBorder: UnderlineInputBorder(
+                              borderSide: BorderSide(
+                                color: MukGenColor.pointBase,
+                                width: 2,
+                              ),
+                            ),
+                          ),
                         ),
                       ),
-                    ),
-                  ),
-                ],
+                      GestureDetector(
+                        onTap: () {
+                          context.read<SignUpBloc>().add(LoadIdDuplicate(id: idController.text));
+                        },
+                        child: Container(
+                          width: 84.0.w,
+                          height: 37.0.h,
+                          decoration: BoxDecoration(
+                            borderRadius: BorderRadius.circular(6.r),
+                            border: Border.all(
+                              color: MukGenColor.primaryLight2,
+                            ),
+                          ),
+                          child: Center(
+                            child: Text(
+                              '중복 확인',
+                              style: TextStyle(
+                                color: MukGenColor.primaryDark2,
+                                fontWeight: FontWeight.w600,
+                                fontSize: 14.sp,
+                                fontFamily: 'MukgenSemiBold',
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                },
               ),
             ],
           ),

--- a/lib/screen/sign_up/view/sign_up_number_page.dart
+++ b/lib/screen/sign_up/view/sign_up_number_page.dart
@@ -5,7 +5,6 @@ import 'package:mukgen_flutter_v1/screen/sign_up/bloc/sign_up_bloc.dart';
 import 'package:mukgen_flutter_v1/screen/sign_up/bloc/sign_up_event.dart';
 import 'package:mukgen_flutter_v1/screen/sign_up/bloc/sign_up_state.dart';
 import 'package:mukgen_flutter_v1/screen/starting_page.dart';
-import 'package:mukgen_flutter_v1/service/auth_service.dart';
 import 'package:mukgen_flutter_v1/widget/mukgen_button.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:mukgen_flutter_v1/widget/mukgen_text_field.dart';

--- a/lib/screen/sign_up/view/sign_up_number_page.dart
+++ b/lib/screen/sign_up/view/sign_up_number_page.dart
@@ -1,5 +1,9 @@
-import 'package:flutter/material.dart';
+  import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mukgen_flutter_v1/common/common.dart';
+import 'package:mukgen_flutter_v1/screen/sign_up/bloc/sign_up_bloc.dart';
+import 'package:mukgen_flutter_v1/screen/sign_up/bloc/sign_up_event.dart';
+import 'package:mukgen_flutter_v1/screen/sign_up/bloc/sign_up_state.dart';
 import 'package:mukgen_flutter_v1/screen/starting_page.dart';
 import 'package:mukgen_flutter_v1/service/auth_service.dart';
 import 'package:mukgen_flutter_v1/widget/mukgen_button.dart';
@@ -179,37 +183,38 @@ class _SignupNumberPageState extends State<SignupNumberPage> {
             ],
           ),
           const Spacer(),
-          MukGenButton(
-            text: "완료",
-            width: 352,
-            height: 55,
-            backgroundColor: _isButtonEnabled
-                ? MukGenColor.pointLight1
-                : MukGenColor.primaryLight2,
-            fontSize: 16,
-            textColor: MukGenColor.white,
-            onPressed: () {
-              if (_isButtonEnabled) {
-                String phone = "";
-                phone += _firstController.text +
-                    _secondController.text +
-                    _thirdController.text;
-                AuthService.postGeneralSignupInfo(widget.name, widget.id,
-                        widget.pwd, widget.pwdcheck, phone, widget.email)
-                    .then(
-                  (value) {
-                    if (value) {
-                      Navigator.of(context).pushAndRemoveUntil(
-                          MaterialPageRoute(
-                              builder: (context) => const StartingPage()),
-                          (route) => false);
-                    }
-                  },
-                );
+          BlocConsumer<SignUpBloc, SignUpState>(
+            listener: (context, state) {
+              if (state is Loaded) {
+                Navigator.of(context).pushAndRemoveUntil(
+                    MaterialPageRoute(
+                        builder: (context) => const StartingPage()),
+                        (route) => false);
               }
             },
+            builder: (context, state) {
+              return MukGenButton(
+                text: "완료",
+                width: 352,
+                height: 55,
+                backgroundColor: _isButtonEnabled
+                    ? MukGenColor.pointLight1
+                    : MukGenColor.primaryLight2,
+                fontSize: 16,
+                textColor: MukGenColor.white,
+                onPressed: () {
+                  if (_isButtonEnabled) {
+                    String phone = "";
+                    phone += _firstController.text +
+                        _secondController.text +
+                        _thirdController.text;
+                    context.read<SignUpBloc>().add(LoadSignUp(nickname: widget.name, accountId: widget.id, password: widget.pwd, passwordCheck: widget.pwdcheck, phoneNumber: phone, mail: widget.email));
+                  }
+                },
+              );
+            }
           ),
-        ],
+        ]
       ),
     );
   }

--- a/lib/service/mail_service.dart
+++ b/lib/service/mail_service.dart
@@ -45,6 +45,7 @@ class MailService {
     );
 
     if (response.statusCode != 200) {
+      print(response.statusCode);
       return false;
     }
     debugPrint(utf8.decode(response.bodyBytes));

--- a/lib/widget/text_field_validation.dart
+++ b/lib/widget/text_field_validation.dart
@@ -14,11 +14,15 @@ class Validation {
     }
   }
 
+  static bool emailValidation = true;
   static String getEmailValidation(String input) {
     RegExp emailRegex = RegExp(r'^[a-zA-Z\d._%+-]+$');
     if (input.isNotEmpty) {
       if (!emailRegex.hasMatch(input)) {
+        emailValidation = false;
         return "잘못된 유형의 이메일 주소입니다.";
+      } else {
+        emailValidation = true;
       }
     }
     return "";


### PR DESCRIPTION
회원가입 페이지 상태관리하였습니다.
인증코드 입력 페이지에 있는 재전송 버튼은 따로 Reload 상태를 만들어서 다음 버튼과 구별하였습니다.
BlocConsumer 나쁘지 않길래 사용해보았습니다. 로그인 페이지에 수정하라고 하셨던 상태관리 코드들 수정하였습니다.