### PR TITLE
🔀 :: 급식 건의 페이지 상태관리 #161

### DIFF
--- a/lib/core/network/jwt_interceptor.dart
+++ b/lib/core/network/jwt_interceptor.dart
@@ -1,0 +1,18 @@
+import 'package:mukgen_flutter_v1/core/jwt_store/jwt_store.dart';
+import 'package:mukgen_flutter_v1/core/jwt_store/jwt_store_properties.dart';
+import 'package:mukgen_flutter_v1/core/network/interceptor.dart';
+import 'package:mukgen_flutter_v1/core/network/mukgen_endpoint.dart';
+
+class JwtInterceptor extends Interceptor<MukgenEndpoint> {
+  final JwtStore _jwtStore;
+
+  JwtInterceptor({required JwtStore jwtStore}) : _jwtStore = jwtStore;
+
+  @override
+  Future<void> onRequest(MukgenEndpoint endpoint) async {
+    if (endpoint.jwtTokenType == JwtTokenType.accessToken) {
+      endpoint.headers['Authorization'] =
+          "Bearer ${await _jwtStore.load(properties: JwtStoreProperties.accessToken)}";
+    }
+  }
+}

--- a/lib/core/network/mukgen_endpoint.dart
+++ b/lib/core/network/mukgen_endpoint.dart
@@ -15,9 +15,9 @@ abstract class MukgenEndpoint extends RequestOptions {
   String get baseUrl => "${s.baseUrl}/$path";
 
   @override
-  Map<String, String> headers = {
+  Map<String, dynamic> headers = {
     'Content-Type': 'application/json',
-    'X-Not-Using-Xquare-Auth': 'true',
+    'X-Not-Using-Xquare-Auth': true,
   };
 }
 

--- a/lib/core/network/networking_provider.dart
+++ b/lib/core/network/networking_provider.dart
@@ -1,5 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mukgen_flutter_v1/core/network/jwt_interceptor.dart';
 import 'package:mukgen_flutter_v1/core/network/networking.dart';
 import 'package:mukgen_flutter_v1/core/network/networking_impl.dart';
 
-final networkingProvider = Provider<Networking>((ref) => NetworkingImpl());
+final networkingProvider = Provider<Networking>(
+    (ref) => NetworkingImpl()..interceptor.add(JwtInterceptor()));

--- a/lib/core/network/networking_provider.dart
+++ b/lib/core/network/networking_provider.dart
@@ -1,7 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mukgen_flutter_v1/core/jwt_store/jwt_store_provider.dart';
 import 'package:mukgen_flutter_v1/core/network/jwt_interceptor.dart';
 import 'package:mukgen_flutter_v1/core/network/networking.dart';
 import 'package:mukgen_flutter_v1/core/network/networking_impl.dart';
 
-final networkingProvider = Provider<Networking>(
-    (ref) => NetworkingImpl()..interceptor.add(JwtInterceptor()));
+final networkingProvider = Provider<Networking>((ref) => NetworkingImpl()
+  ..interceptor.add(JwtInterceptor(jwtStore: ref.watch(jwtStoreProvider))));

--- a/lib/core/network/request_options.dart
+++ b/lib/core/network/request_options.dart
@@ -10,5 +10,5 @@ abstract class RequestOptions {
 
   BaseRequestDTO? get body;
 
-  Map<String, String> headers = {};
+  Map<String, dynamic> headers = {};
 }

--- a/lib/data/data_source/meal_suggestion/remote/remote_meal_suggestion_data_source.dart
+++ b/lib/data/data_source/meal_suggestion/remote/remote_meal_suggestion_data_source.dart
@@ -42,11 +42,12 @@ class RemoteMealSuggestionDataSource {
   Future<Result<List<MealSuggestionEntity>, Exception>>
       readAllMealSuggestion() async {
     final res = await _networking.request<ReadAllMealSuggestionResponseDTO,
-            ReadAllMealSuggestionResponseDTO>(
+            List<MealSuggestionResponse>>(
         endpoint: MealSuggestionEndpoint.readAllMealSuggestion(),
         responseType: ReadAllMealSuggestionResponseDTO());
     return switch (res) {
-      Success(value: final value) => Success(value: value.toEntity()),
+      Success(value: final value) =>
+        Success(value: value.map((e) => e.toEntity()).toList()),
       Failure(exception: final e) => Failure(exception: e),
     };
   }

--- a/lib/data/dto/meal_suggestion/response/read_all_meal_suggestion_response_dto.dart
+++ b/lib/data/dto/meal_suggestion/response/read_all_meal_suggestion_response_dto.dart
@@ -3,18 +3,18 @@ import 'package:mukgen_flutter_v1/domain/entity/meal_suggestion/meal_suggestion_
 
 final class ReadAllMealSuggestionResponseDTO
     extends BaseResponseDTO<List<MealSuggestionEntity>> {
-  late List<MealSuggestionResponse> mealSuggestions;
+  List<MealSuggestionResponse> mealSuggestions = [];
 
   ReadAllMealSuggestionResponseDTO();
 
   @override
-  fromJson(Map<String, dynamic> json) {
-    if (json['mealSuggestionResponseList'] != null) {
-      mealSuggestions = List.empty(growable: true);
-      json['mealSuggestionResponseList'].forEach((data) {
+  List<MealSuggestionResponse> fromJson(Map<String, dynamic> json) {
+    if (json["mealSuggestionResponseList"] != null) {
+      json["mealSuggestionResponseList"].forEach((data) {
         mealSuggestions.add(MealSuggestionResponse.fromJson(data));
       });
     }
+    return mealSuggestions;
   }
 
   @override
@@ -39,7 +39,8 @@ final class MealSuggestionResponse
         ..checked = json['checked'];
 
   @override
-  fromJson(Map<String, dynamic> json) => MealSuggestionResponse.fromJson(json);
+  MealSuggestionResponse fromJson(Map<String, dynamic> json) =>
+      MealSuggestionResponse.fromJson(json);
 
   @override
   MealSuggestionEntity toEntity() => MealSuggestionEntity(

--- a/lib/data/dto/meal_suggestion/response/read_all_meal_suggestion_response_dto.dart
+++ b/lib/data/dto/meal_suggestion/response/read_all_meal_suggestion_response_dto.dart
@@ -34,7 +34,7 @@ final class MealSuggestionResponse
       MealSuggestionResponse()
         ..id = json['id']
         ..likeCount = json['likeCount']
-        ..dislikeCount = json['disCount']
+        ..dislikeCount = json['dislikeCount']
         ..content = json['content']
         ..checked = json['checked'];
 

--- a/lib/screen/starting_page.dart
+++ b/lib/screen/starting_page.dart
@@ -3,10 +3,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:mukgen_flutter_v1/core/component/text/pretendard/ptd_text_widget.dart';
 import 'package:mukgen_flutter_v1/core/constant/mukgen_color.dart';
 import 'package:mukgen_flutter_v1/screen/sign_in/view/sign_in_page.dart';
-import 'package:mukgen_flutter_v1/screen/sign_up/view/sign_up_email_confirm_page.dart';
-import 'package:mukgen_flutter_v1/screen/sign_up/view/sign_up_email_input_page.dart';
 import 'package:mukgen_flutter_v1/screen/sign_up/view/sign_up_main_page.dart';
-import 'package:mukgen_flutter_v1/screen/sign_up/view/sign_up_name_page.dart';
 import 'package:mukgen_flutter_v1/screen/widget/mukgen_button.dart';
 
 class StartingPage extends StatefulWidget {
@@ -19,7 +16,8 @@ class StartingPage extends StatefulWidget {
 class _StartingPageState extends State<StartingPage> {
   @override
   Widget build(BuildContext context) {
-    return PopScope(
+    return WillPopScope(
+      onWillPop: null,
       child: Scaffold(
         backgroundColor: MukGenColor.primaryLight3,
         body: Column(

--- a/lib/screen/suggestion_main/provider/meal_suggestion_page_state.dart
+++ b/lib/screen/suggestion_main/provider/meal_suggestion_page_state.dart
@@ -1,31 +1,32 @@
+import 'package:equatable/equatable.dart';
 import 'package:mukgen_flutter_v1/domain/entity/meal_suggestion/meal_suggestion_entity.dart';
 
-sealed class MealSuggestionPageState {
-  MealSuggestionPageState();
+enum MealSuggestionPageStateEnum { initial, loading, success, failure }
 
-  factory MealSuggestionPageState.initial() = Initial;
+class MealSuggestionPageState extends Equatable {
+  List<MealSuggestionEntity> mealSuggestions = [];
+  final String failMessage;
+  final MealSuggestionPageStateEnum state;
 
-  factory MealSuggestionPageState.loading() = Loading;
+  MealSuggestionPageState(
+      {required this.mealSuggestions,
+      required this.state,
+      required this.failMessage});
 
-  factory MealSuggestionPageState.failure({required String errorMessage}) =
-      Failure;
+  MealSuggestionPageState.initial({
+    this.state = MealSuggestionPageStateEnum.initial,
+    this.failMessage = "",
+  });
 
-  factory MealSuggestionPageState.success(
-      {required List<MealSuggestionEntity> mealSuggestions}) = Success;
-}
+  @override
+  List<Object> get props => [mealSuggestions];
 
-final class Initial extends MealSuggestionPageState {}
-
-final class Loading extends MealSuggestionPageState {}
-
-final class Failure extends MealSuggestionPageState {
-  final String errorMessage;
-
-  Failure({required this.errorMessage});
-}
-
-final class Success extends MealSuggestionPageState {
-  final List<MealSuggestionEntity> mealSuggestions;
-
-  Success({required this.mealSuggestions});
+  MealSuggestionPageState copyWith(
+          {List<MealSuggestionEntity>? mealSuggestions,
+          MealSuggestionPageStateEnum? state,
+          String? failMessage}) =>
+      MealSuggestionPageState(
+          mealSuggestions: mealSuggestions ?? this.mealSuggestions,
+          state: state ?? this.state,
+          failMessage: failMessage ?? this.failMessage);
 }

--- a/lib/screen/suggestion_main/provider/meal_suggestion_page_state.dart
+++ b/lib/screen/suggestion_main/provider/meal_suggestion_page_state.dart
@@ -1,0 +1,31 @@
+import 'package:mukgen_flutter_v1/domain/entity/meal_suggestion/meal_suggestion_entity.dart';
+
+sealed class MealSuggestionPageState {
+  MealSuggestionPageState();
+
+  factory MealSuggestionPageState.initial() = Initial;
+
+  factory MealSuggestionPageState.loading() = Loading;
+
+  factory MealSuggestionPageState.failure({required String errorMessage}) =
+      Failure;
+
+  factory MealSuggestionPageState.success(
+      {required List<MealSuggestionEntity> mealSuggestions}) = Success;
+}
+
+final class Initial extends MealSuggestionPageState {}
+
+final class Loading extends MealSuggestionPageState {}
+
+final class Failure extends MealSuggestionPageState {
+  final String errorMessage;
+
+  Failure({required this.errorMessage});
+}
+
+final class Success extends MealSuggestionPageState {
+  final List<MealSuggestionEntity> mealSuggestions;
+
+  Success({required this.mealSuggestions});
+}

--- a/lib/screen/suggestion_main/provider/meal_suggestion_page_view_model.dart
+++ b/lib/screen/suggestion_main/provider/meal_suggestion_page_view_model.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mukgen_flutter_v1/core/network/result.dart' as r;
+import 'package:mukgen_flutter_v1/domain/use_case/meal_suggestion/add_meal_suggestion_dislike_use_case.dart';
+import 'package:mukgen_flutter_v1/domain/use_case/meal_suggestion/add_meal_suggestion_like_use_case.dart';
+import 'package:mukgen_flutter_v1/domain/use_case/meal_suggestion/create_meal_suggestion_use_case.dart';
+import 'package:mukgen_flutter_v1/domain/use_case/meal_suggestion/delete_meal_suggestion_use_case.dart';
+import 'package:mukgen_flutter_v1/domain/use_case/meal_suggestion/read_all_meal_suggestion_use_case.dart';
+import 'package:mukgen_flutter_v1/domain/use_case/meal_suggestion/update_meal_suggestion_use_case.dart';
+import 'package:mukgen_flutter_v1/screen/suggestion_main/provider/meal_suggestion_page_state.dart';
+
+class MealSuggestionPageViewModel
+    extends StateNotifier<MealSuggestionPageState> {
+  final AddMealSuggestionDislikeUseCase _addMealSuggestionDislikeUseCase;
+  final AddMealSuggestionLikeUseCase _addMealSuggestionLikeUseCase;
+  final CreateMealSuggestionUseCase _createMealSuggestionUseCase;
+  final DeleteMealSuggestionUseCase _deleteMealSuggestionUseCase;
+  final ReadAllMealSuggestionUseCase _readAllMealSuggestionUseCase;
+  final UpdateMealSuggestionUseCase _updateMealSuggestionUseCase;
+
+  MealSuggestionPageViewModel(
+      {required AddMealSuggestionDislikeUseCase addMealSuggestionDislikeUseCase,
+      required AddMealSuggestionLikeUseCase addMealSuggestionLikeUseCase,
+      required CreateMealSuggestionUseCase createMealSuggestionUseCase,
+      required DeleteMealSuggestionUseCase deleteMealSuggestionUseCase,
+      required ReadAllMealSuggestionUseCase readAllMealSuggestionUseCase,
+      required UpdateMealSuggestionUseCase updateMealSuggestionUseCase})
+      : _addMealSuggestionDislikeUseCase = addMealSuggestionDislikeUseCase,
+        _addMealSuggestionLikeUseCase = addMealSuggestionLikeUseCase,
+        _createMealSuggestionUseCase = createMealSuggestionUseCase,
+        _deleteMealSuggestionUseCase = deleteMealSuggestionUseCase,
+        _readAllMealSuggestionUseCase = readAllMealSuggestionUseCase,
+        _updateMealSuggestionUseCase = updateMealSuggestionUseCase,
+        super(MealSuggestionPageState.initial());
+
+  Future<void> readAllMealSuggestion() async {
+    state = MealSuggestionPageState.loading();
+    final res = await _readAllMealSuggestionUseCase.execute();
+    switch (res) {
+      case r.Success(value: final value):
+        state = MealSuggestionPageState.success(mealSuggestions: value);
+      case r.Failure(exception: final e):
+        state = MealSuggestionPageState.failure(errorMessage: e.toString());
+    }
+  }
+}

--- a/lib/screen/suggestion_main/provider/meal_suggestion_page_view_model.dart
+++ b/lib/screen/suggestion_main/provider/meal_suggestion_page_view_model.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mukgen_flutter_v1/core/network/result.dart' as r;
+import 'package:mukgen_flutter_v1/domain/entity/meal_suggestion/meal_suggestion_entity.dart';
 import 'package:mukgen_flutter_v1/domain/use_case/meal_suggestion/add_meal_suggestion_dislike_use_case.dart';
 import 'package:mukgen_flutter_v1/domain/use_case/meal_suggestion/add_meal_suggestion_like_use_case.dart';
 import 'package:mukgen_flutter_v1/domain/use_case/meal_suggestion/create_meal_suggestion_use_case.dart';
@@ -33,13 +34,39 @@ class MealSuggestionPageViewModel
         super(MealSuggestionPageState.initial());
 
   Future<void> readAllMealSuggestion() async {
-    state = MealSuggestionPageState.loading();
+    state = state.copyWith(state: MealSuggestionPageStateEnum.loading);
     final res = await _readAllMealSuggestionUseCase.execute();
     switch (res) {
       case r.Success(value: final value):
-        state = MealSuggestionPageState.success(mealSuggestions: value);
+        state = state.copyWith(
+            state: MealSuggestionPageStateEnum.success, mealSuggestions: value);
       case r.Failure(exception: final e):
-        state = MealSuggestionPageState.failure(errorMessage: e.toString());
+        state = state.copyWith(
+            state: MealSuggestionPageStateEnum.failure, mealSuggestions: []);
+    }
+  }
+
+  Future<void> addMealSuggestionDislike({required int mealSuggestionId}) async {
+    final res = await _addMealSuggestionDislikeUseCase.execute(
+        mealSuggestionId: mealSuggestionId);
+    switch (res) {
+      case r.Success():
+        state = state.copyWith(
+            state: MealSuggestionPageStateEnum.success,
+            mealSuggestions: state.mealSuggestions
+                .map((e) => e.id == mealSuggestionId
+                    ? MealSuggestionEntity(
+                        id: e.id,
+                        likeCount: e.likeCount,
+                        dislikeCount: e.dislikeCount + 1,
+                        content: e.content,
+                        checked: e.checked)
+                    : e)
+                .toList());
+      case r.Failure(exception: final e):
+        state = state.copyWith(
+            state: MealSuggestionPageStateEnum.failure,
+            failMessage: e.toString());
     }
   }
 }

--- a/lib/screen/suggestion_main/provider/meal_suggestion_page_view_model_provider.dart
+++ b/lib/screen/suggestion_main/provider/meal_suggestion_page_view_model_provider.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mukgen_flutter_v1/domain/use_case/meal_suggestion/providers/add_meal_suggestion_dislike_use_case_provider.dart';
+import 'package:mukgen_flutter_v1/domain/use_case/meal_suggestion/providers/add_meal_suggestion_like_use_case_provider.dart';
+import 'package:mukgen_flutter_v1/domain/use_case/meal_suggestion/providers/create_meal_suggestion_use_case_provider.dart';
+import 'package:mukgen_flutter_v1/domain/use_case/meal_suggestion/providers/delete_meal_suggestion_use_case_provider.dart';
+import 'package:mukgen_flutter_v1/domain/use_case/meal_suggestion/providers/read_all_meal_suggestion_use_case_provider.dart';
+import 'package:mukgen_flutter_v1/domain/use_case/meal_suggestion/providers/update_meal_suggestion_use_case_provider.dart';
+import 'package:mukgen_flutter_v1/screen/suggestion_main/provider/meal_suggestion_page_state.dart';
+import 'package:mukgen_flutter_v1/screen/suggestion_main/provider/meal_suggestion_page_view_model.dart';
+
+final mealSuggestionPageViewModelProvider =
+    StateNotifierProvider<MealSuggestionPageViewModel, MealSuggestionPageState>(
+  (ref) => MealSuggestionPageViewModel(
+    addMealSuggestionDislikeUseCase:
+        ref.watch(addMealSuggestionDislikeUseCaseProvider),
+    addMealSuggestionLikeUseCase:
+        ref.watch(addMealSuggestionLikeUseCaseProvider),
+    createMealSuggestionUseCase: ref.watch(createMealSuggestionUseCaseProvider),
+    deleteMealSuggestionUseCase: ref.watch(deleteMealSuggestionUseCaseProvider),
+    readAllMealSuggestionUseCase:
+        ref.watch(readAllMealSuggestionUseCaseProvider),
+    updateMealSuggestionUseCase: ref.watch(updateMealSuggestionUseCaseProvider),
+  ),
+);

--- a/lib/screen/suggestion_main/view/main_suggestion_page.dart
+++ b/lib/screen/suggestion_main/view/main_suggestion_page.dart
@@ -1,29 +1,27 @@
 import 'package:flutter/material.dart';
-import 'package:mukgen_flutter_v1/core/constant/mukgen_color.dart';
-import 'package:mukgen_flutter_v1/model/suggestion/total_suggestion.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
-import 'package:mukgen_flutter_v1/service/suggestion_service.dart';
+import 'package:mukgen_flutter_v1/core/constant/mukgen_color.dart';
+import 'package:mukgen_flutter_v1/screen/suggestion_main/provider/meal_suggestion_page_state.dart';
+import 'package:mukgen_flutter_v1/screen/suggestion_main/provider/meal_suggestion_page_view_model_provider.dart';
 
-class MainSuggestionPage extends StatefulWidget {
+class MainSuggestionPage extends ConsumerStatefulWidget {
+  final VoidCallback onPosting;
+
   const MainSuggestionPage({Key? key, required this.onPosting})
       : super(key: key);
 
-  final VoidCallback onPosting;
-
   @override
-  State<MainSuggestionPage> createState() => _MainSuggestionPageState();
+  ConsumerState<MainSuggestionPage> createState() => _MainSuggestionPageState();
 }
 
-class _MainSuggestionPageState extends State<MainSuggestionPage> {
-  Future<TotalSuggestion>? totalSuggestion;
-
+class _MainSuggestionPageState extends ConsumerState<MainSuggestionPage> {
   double lengthContainer(int length) {
     Map<int, double> widthMap = {
       4: 65.0.w,
       3: 52.0.w,
       2: 46.0.w,
     };
-
     return widthMap[length] ?? 40.0.w;
   }
 
@@ -32,8 +30,18 @@ class _MainSuggestionPageState extends State<MainSuggestionPage> {
   }
 
   @override
+  void initState() {
+    super.initState();
+    Future.delayed(
+        Duration.zero,
+        () => ref
+            .watch(mealSuggestionPageViewModelProvider.notifier)
+            .readAllMealSuggestion());
+  }
+
+  @override
   Widget build(BuildContext context) {
-    totalSuggestion = SuggestionService.getTotalSuggestionInfo();
+    final viewModelState = ref.watch(mealSuggestionPageViewModelProvider);
     return Scaffold(
       backgroundColor: MukGenColor.white,
       appBar: AppBar(
@@ -50,232 +58,210 @@ class _MainSuggestionPageState extends State<MainSuggestionPage> {
           ),
         ),
       ),
-      body: SingleChildScrollView(
-        child: Column(
-          children: [
-            SizedBox(height: 10.0.h),
-            SizedBox(
-              height: 658.0.h,
-              width: double.infinity,
-              child: RefreshIndicator(
-                onRefresh: () async {
-                  setState(() {
-                    totalSuggestion =
-                        SuggestionService.getTotalSuggestionInfo();
-                  });
-                },
-                child: FutureBuilder(
-                  future: totalSuggestion,
-                  builder: (context, snapshot) {
-                    if (snapshot.hasData) {
-                      return Center(
+      body: Center(
+        child: switch (viewModelState.state) {
+          MealSuggestionPageStateEnum.initial ||
+          MealSuggestionPageStateEnum.loading =>
+            const CircularProgressIndicator(),
+          MealSuggestionPageStateEnum.failure =>
+            Text(viewModelState.failMessage),
+          MealSuggestionPageStateEnum.success => SingleChildScrollView(
+              child: Column(
+                children: [
+                  SizedBox(height: 10.0.h),
+                  SizedBox(
+                    height: 658.0.h,
+                    width: double.infinity,
+                    child: RefreshIndicator(
+                      onRefresh: () async => ref
+                          .watch(mealSuggestionPageViewModelProvider.notifier)
+                          .readAllMealSuggestion(),
+                      child: Center(
                         child: SizedBox(
                           width: 353.0.w,
                           child: GridView.builder(
-                              gridDelegate:
-                                  SliverGridDelegateWithMaxCrossAxisExtent(
-                                maxCrossAxisExtent: 171.5.w,
-                                mainAxisSpacing: 10.0.h,
-                                crossAxisSpacing: 10.0.w,
-                                childAspectRatio: 171.5.w / 150.0.h,
-                              ),
-                              itemCount: snapshot
-                                  .data!.mealSuggestionResponseList!.length,
-                              itemBuilder: (context, index) {
-                                String like = formatCount(snapshot
-                                    .data!
-                                    .mealSuggestionResponseList![index]
-                                    .likeCount!);
-                                String dislike = formatCount(snapshot
-                                    .data!
-                                    .mealSuggestionResponseList![index]
-                                    .dislikeCount!);
-                                return Container(
-                                  decoration: BoxDecoration(
-                                    color: MukGenColor.postIt1,
-                                    borderRadius: BorderRadius.circular(16.r),
-                                  ),
-                                  child: Column(
-                                    children: [
-                                      SizedBox(height: 12.0.h),
-                                      SizedBox(
-                                        width: 139.5.w,
-                                        height: 24.0.h,
-                                        child: Row(
-                                          mainAxisAlignment:
-                                              MainAxisAlignment.spaceBetween,
-                                          children: [
-                                            Text(
-                                              'ㅇㅇ',
-                                              style: TextStyle(
-                                                color:
-                                                    MukGenColor.primaryLight1,
-                                                fontSize: 14.sp,
-                                                fontFamily: 'MukgenSemiBold',
-                                                fontWeight: FontWeight.w600,
-                                              ),
+                            gridDelegate:
+                                SliverGridDelegateWithMaxCrossAxisExtent(
+                              maxCrossAxisExtent: 171.5.w,
+                              mainAxisSpacing: 10.0.h,
+                              crossAxisSpacing: 10.0.w,
+                              childAspectRatio: 171.5.w / 150.0.h,
+                            ),
+                            itemCount: viewModelState.mealSuggestions.length,
+                            itemBuilder: (context, index) {
+                              String like = formatCount(viewModelState
+                                  .mealSuggestions[index].likeCount);
+                              String dislike = formatCount(viewModelState
+                                  .mealSuggestions[index].dislikeCount);
+                              return Container(
+                                decoration: BoxDecoration(
+                                  color: MukGenColor.postIt1,
+                                  borderRadius: BorderRadius.circular(16.r),
+                                ),
+                                child: Column(
+                                  children: [
+                                    SizedBox(height: 12.0.h),
+                                    SizedBox(
+                                      width: 139.5.w,
+                                      height: 24.0.h,
+                                      child: Row(
+                                        mainAxisAlignment:
+                                            MainAxisAlignment.spaceBetween,
+                                        children: [
+                                          Text(
+                                            'ㅇㅇ',
+                                            style: TextStyle(
+                                              color: MukGenColor.primaryLight1,
+                                              fontSize: 14.sp,
+                                              fontFamily: 'MukgenSemiBold',
+                                              fontWeight: FontWeight.w600,
                                             ),
-                                            Icon(
-                                              Icons.check_circle_rounded,
-                                              color: snapshot
-                                                      .data!
-                                                      .mealSuggestionResponseList![
-                                                          index]
-                                                      .checked!
-                                                  ? MukGenColor.pointBase
-                                                  : MukGenColor.primaryLight1,
-                                              size: 24.sp,
-                                            ),
-                                          ],
-                                        ),
-                                      ),
-                                      SizedBox(height: 6.0.h),
-                                      SizedBox(
-                                        width: 139.5.w,
-                                        height: 70.0.h,
-                                        child: Text(
-                                          snapshot
-                                              .data!
-                                              .mealSuggestionResponseList![
-                                                  index]
-                                              .content!
-                                              .toString(),
-                                          style: TextStyle(
-                                            color: MukGenColor.black,
-                                            fontSize: 12.sp,
-                                            fontWeight: FontWeight.w400,
-                                            fontFamily: 'MukgenRegular',
                                           ),
+                                          Icon(
+                                            Icons.check_circle_rounded,
+                                            color: viewModelState
+                                                    .mealSuggestions[index]
+                                                    .checked
+                                                ? MukGenColor.pointBase
+                                                : MukGenColor.primaryLight1,
+                                            size: 24.sp,
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                    SizedBox(height: 6.0.h),
+                                    SizedBox(
+                                      width: 139.5.w,
+                                      height: 70.0.h,
+                                      child: Text(
+                                        viewModelState
+                                            .mealSuggestions[index].content,
+                                        style: TextStyle(
+                                          color: MukGenColor.black,
+                                          fontSize: 12.sp,
+                                          fontWeight: FontWeight.w400,
+                                          fontFamily: 'MukgenRegular',
                                         ),
                                       ),
-                                      SizedBox(height: 6.0.h),
-                                      SizedBox(
-                                        width: 140.0.w,
-                                        height: 20.0.h,
-                                        child: Row(
-                                          mainAxisAlignment:
-                                              MainAxisAlignment.end,
-                                          children: [
-                                            GestureDetector(
-                                              onTap: () {
-                                                SuggestionService
-                                                    .postLikeSuggestionInfo(snapshot
-                                                        .data!
-                                                        .mealSuggestionResponseList![
-                                                            index]
-                                                        .id!);
-                                              },
-                                              child: Container(
-                                                width: lengthContainer(
-                                                    like.length),
-                                                height: 20.0.h,
-                                                decoration: BoxDecoration(
-                                                  color: MukGenColor.white,
-                                                  borderRadius:
-                                                      BorderRadius.circular(
-                                                          8.07.r),
-                                                ),
-                                                child: Row(
-                                                  mainAxisAlignment:
-                                                      MainAxisAlignment.center,
-                                                  children: [
-                                                    Icon(
-                                                      Icons.favorite_rounded,
-                                                      size: 14.sp,
-                                                      color: MukGenColor
-                                                          .pointLight1,
-                                                    ),
-                                                    SizedBox(width: 4.0.w),
-                                                    StatefulBuilder(
-                                                      builder:
-                                                          (context, likeIndex) {
-                                                        return Text(
-                                                          like.toString(),
-                                                          style: TextStyle(
-                                                            color: MukGenColor
-                                                                .primaryLight1,
-                                                            fontSize: 12.11.sp,
-                                                            fontFamily:
-                                                                'InterBold',
-                                                          ),
-                                                        );
-                                                      },
-                                                    ),
-                                                  ],
-                                                ),
+                                    ),
+                                    SizedBox(height: 6.0.h),
+                                    SizedBox(
+                                      width: 140.0.w,
+                                      height: 20.0.h,
+                                      child: Row(
+                                        mainAxisAlignment:
+                                            MainAxisAlignment.end,
+                                        children: [
+                                          GestureDetector(
+                                            onTap: () {},
+                                            child: Container(
+                                              width:
+                                                  lengthContainer(like.length),
+                                              height: 20.0.h,
+                                              decoration: BoxDecoration(
+                                                color: MukGenColor.white,
+                                                borderRadius:
+                                                    BorderRadius.circular(
+                                                        8.07.r),
+                                              ),
+                                              child: Row(
+                                                mainAxisAlignment:
+                                                    MainAxisAlignment.center,
+                                                children: [
+                                                  Icon(
+                                                    Icons.favorite_rounded,
+                                                    size: 14.sp,
+                                                    color:
+                                                        MukGenColor.pointLight1,
+                                                  ),
+                                                  SizedBox(width: 4.0.w),
+                                                  StatefulBuilder(
+                                                    builder:
+                                                        (context, likeIndex) {
+                                                      return Text(
+                                                        like,
+                                                        style: TextStyle(
+                                                          color: MukGenColor
+                                                              .primaryLight1,
+                                                          fontSize: 12.11.sp,
+                                                          fontFamily:
+                                                              'InterBold',
+                                                        ),
+                                                      );
+                                                    },
+                                                  ),
+                                                ],
                                               ),
                                             ),
-                                            SizedBox(width: 4.0.w),
-                                            GestureDetector(
-                                              onTap: () {
-                                                SuggestionService
-                                                    .postDislikeSuggestionInfo(
-                                                        snapshot
-                                                            .data!
-                                                            .mealSuggestionResponseList![
+                                          ),
+                                          SizedBox(width: 4.0.w),
+                                          GestureDetector(
+                                            onTap: () => ref
+                                                .watch(
+                                                    mealSuggestionPageViewModelProvider
+                                                        .notifier)
+                                                .addMealSuggestionDislike(
+                                                    mealSuggestionId:
+                                                        viewModelState
+                                                            .mealSuggestions[
                                                                 index]
-                                                            .id!);
-                                              },
-                                              child: Container(
-                                                width: lengthContainer(
-                                                    dislike.length),
-                                                height: 20.0.h,
-                                                decoration: BoxDecoration(
-                                                  color: MukGenColor.white,
-                                                  borderRadius:
-                                                      BorderRadius.circular(
-                                                          8.07.r),
-                                                ),
-                                                child: Row(
-                                                  mainAxisAlignment:
-                                                      MainAxisAlignment.center,
-                                                  children: [
-                                                    Icon(
-                                                      Icons.close_rounded,
-                                                      size: 14.sp,
-                                                      color: MukGenColor
-                                                          .pointLight1,
-                                                    ),
-                                                    SizedBox(width: 4.0.w),
-                                                    StatefulBuilder(
-                                                      builder: (context,
-                                                          dislikeIndex) {
-                                                        return Text(
-                                                          dislike.toString(),
-                                                          style: TextStyle(
-                                                            color: MukGenColor
-                                                                .primaryLight1,
-                                                            fontSize: 12.11.sp,
-                                                            fontFamily:
-                                                                'InterBold',
-                                                          ),
-                                                        );
-                                                      },
-                                                    ),
-                                                  ],
-                                                ),
+                                                            .id),
+                                            child: Container(
+                                              width: lengthContainer(
+                                                  dislike.length),
+                                              height: 20.0.h,
+                                              decoration: BoxDecoration(
+                                                color: MukGenColor.white,
+                                                borderRadius:
+                                                    BorderRadius.circular(
+                                                        8.07.r),
+                                              ),
+                                              child: Row(
+                                                mainAxisAlignment:
+                                                    MainAxisAlignment.center,
+                                                children: [
+                                                  Icon(
+                                                    Icons.close_rounded,
+                                                    size: 14.sp,
+                                                    color:
+                                                        MukGenColor.pointLight1,
+                                                  ),
+                                                  SizedBox(width: 4.0.w),
+                                                  StatefulBuilder(
+                                                    builder: (context,
+                                                        dislikeIndex) {
+                                                      return Text(
+                                                        dislike,
+                                                        style: TextStyle(
+                                                          color: MukGenColor
+                                                              .primaryLight1,
+                                                          fontSize: 12.11.sp,
+                                                          fontFamily:
+                                                              'InterBold',
+                                                        ),
+                                                      );
+                                                    },
+                                                  ),
+                                                ],
                                               ),
                                             ),
-                                          ],
-                                        ),
+                                          ),
+                                        ],
                                       ),
-                                    ],
-                                  ),
-                                );
-                              }),
+                                    ),
+                                  ],
+                                ),
+                              );
+                            },
+                          ),
                         ),
-                      );
-                    } else if (snapshot.hasError) {
-                      return Center(child: Text(snapshot.error.toString()));
-                    } else {
-                      return const Center(child: CircularProgressIndicator());
-                    }
-                  },
-                ),
+                      ),
+                    ),
+                  ),
+                ],
               ),
             ),
-          ],
-        ),
+        },
       ),
       floatingActionButton: SizedBox(
         width: 70.0.w,
@@ -283,9 +269,7 @@ class _MainSuggestionPageState extends State<MainSuggestionPage> {
         child: FittedBox(
           child: FloatingActionButton(
             heroTag: 'addmeal-suggestion',
-            onPressed: () {
-              widget.onPosting();
-            },
+            onPressed: widget.onPosting,
             elevation: 0,
             backgroundColor: MukGenColor.pointBase,
             child: Icon(Icons.add, size: 30.0.sp, color: MukGenColor.white),

--- a/lib/screen/widget/main_navigator.dart
+++ b/lib/screen/widget/main_navigator.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:mukgen_flutter_v1/core/constant/mukgen_color.dart';
 import 'package:mukgen_flutter_v1/screen/board_detail/view/main_board_detail_page.dart';
 import 'package:mukgen_flutter_v1/screen/board_main/view/main_board_page.dart';
 import 'package:mukgen_flutter_v1/screen/board_posting/view/main_board_posting_page.dart';
 import 'package:mukgen_flutter_v1/screen/delivery_main/view/main_delivery_party_page.dart';
 import 'package:mukgen_flutter_v1/screen/delivery_posting/view/delivery_what_food_page.dart';
+import 'package:mukgen_flutter_v1/screen/main/view/main_page.dart';
 import 'package:mukgen_flutter_v1/screen/mypage/view/my_page.dart';
 import 'package:mukgen_flutter_v1/screen/review_detail/view/main_review_detail_page.dart';
 import 'package:mukgen_flutter_v1/screen/review_main/view/main_review_page.dart';
@@ -12,7 +14,6 @@ import 'package:mukgen_flutter_v1/screen/review_select/view/main_review_select_p
 import 'package:mukgen_flutter_v1/screen/suggestion_main/view/main_suggestion_page.dart';
 import 'package:mukgen_flutter_v1/screen/suggestion_posting/view/main_suggestion_posting_page.dart';
 import 'package:mukgen_flutter_v1/screen/widget/custom_icons.dart';
-import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:transition/transition.dart';
 
 class MainNavigator extends StatefulWidget {
@@ -33,13 +34,12 @@ class _MainNavigatorState extends State<MainNavigator> {
     GlobalKey<NavigatorState>()
   ];
 
-
-
   @override
   Widget build(BuildContext context) {
     return WillPopScope(
       onWillPop: () async {
-        final isFirstRouteInCurrentTab = !await _navigatorKeys[_selectedIndex].currentState!.maybePop();
+        final isFirstRouteInCurrentTab =
+            !await _navigatorKeys[_selectedIndex].currentState!.maybePop();
         return isFirstRouteInCurrentTab;
       },
       child: Scaffold(
@@ -125,17 +125,17 @@ class _MainNavigatorState extends State<MainNavigator> {
     return {
       '/': (context) {
         return [
-          // MainHomePage(
-          //   onMyPage: () {
-          //     onNext(const MyPage());
-          //   },
-          //   onDetail: (int boardId) {
-          //     onNext(MainBoardDetailPage(
-          //       boardId: boardId,
-          //       query: "total",
-          //     ));
-          //   },
-          // ),
+          MainHomePage(
+            onMyPage: () {
+              onNext(const MyPage());
+            },
+            onDetail: (int boardId) {
+              onNext(MainBoardDetailPage(
+                boardId: boardId,
+                query: "total",
+              ));
+            },
+          ),
           MainBoardPage(
             onPosting: (String query) {
               onNext(MainBoardPostingPage(query: query));


### PR DESCRIPTION
급식 건의 페이지 뷰를 상태관리 해주었습니다.
pr 크기가 커질까봐 급식 건의 목록 받아오기와 싫어요 추가 기능만 구현해놨습니다.
state를 enum과 데이터 클래스로 분리해서 뷰 안의 다른 데이터를 상태관리할때도 용이합니다만..
success 상태일때도 failMessage에 접근할 수 있다는 점이 좀 불안하네요 ㅠ 서로 분리하는 작업은 추후에 고려해보겠습니다